### PR TITLE
Fixed path of docker volume creation

### DIFF
--- a/chapters/modules/chapter_1/pages/environment_setup.adoc
+++ b/chapters/modules/chapter_1/pages/environment_setup.adoc
@@ -208,7 +208,7 @@ To run a container from the image, execute the `docker run` command. To make cer
 
 [source, bash]
 ----
-docker run -it --name stark-env -v Desktop/stark-apps/contracts:/contracts artudev19/cairo-env:1.0.0-alpha.6
+docker run -it --name stark-env -v /Desktop/stark-apps/contracts:/contracts artudev19/cairo-env:1.0.0-alpha.6
 ----
 
 This command runs a container named `stark-env` (ensure your Docker daemon is running) and opens a terminal where you can execute Starknet and Cairo commands. In the example above, the Cairo contracts from your local machine will be in the `stark-app/contracts` directory, while in the container, they will be in the `contracts` path.


### PR DESCRIPTION
When executing the instruction without the slash throws the next error: 

docker: Error response from daemon: create Desktop/stark-apps/contracts: "Desktop/stark-apps/contracts" includes invalid characters for a local volume name, only "[a-zA-Z0-9][a-zA-Z0-9_.-]" are allowed. If you intended to pass a host directory, use absolute path.
See 'docker run --help'.

Fix: adding a slash before the path works fine

As extra info, i'm using bash in Ubuntu

@omarespejel 