### PR TITLE
Clarify account funding steps

### DIFF
--- a/chapters/book/modules/chapter_1/pages/deploying_contracts.adoc
+++ b/chapters/book/modules/chapter_1/pages/deploying_contracts.adoc
@@ -57,7 +57,7 @@ NOTE: This is a modified version of the OpenZeppelin account contract. The signa
 differently.
 ----
 
-Next step is to fund it.
+Next step is to fund it. Use one of the following methods:
 
 * Use the https://faucet.goerli.starknet.io[faucet] to get some funds and send them to the account
 * Bridge funds using https://goerli.starkgate.starknet.io/[Starkgate]


### PR DESCRIPTION
Previously, it looked like we had to get ETH, and bridge it (which is how we fund testnet GUI wallets sometimes).