### PR TITLE
Update event.adoc

### DIFF
--- a/chapters/book/modules/chapter_2/pages/event.adoc
+++ b/chapters/book/modules/chapter_2/pages/event.adoc
@@ -17,7 +17,7 @@ enum Event {
 }
 ----
 
-In our voting contract, we have two events, **`VoteCast`** and **`UnauthorizedAttempt`** which are defined in the enum above. The **`VoteCast`** event is emitted when a vote is cast. The event takes two parameters: the voter's address and the vote value (0 for No, 1 for Yes).
+The voting contract has two events, *`VoteCast`* and *`UnauthorizedAttempt`*, which are defined in the enum above. The *`VoteCast`* event is emitted when a vote is cast. The event takes two parameters: the voter's address and the vote value: 0 for No, 1 for Yes.
 
 [source,rust]
 ----

--- a/chapters/book/modules/chapter_2/pages/event.adoc
+++ b/chapters/book/modules/chapter_2/pages/event.adoc
@@ -6,7 +6,7 @@ Events are a useful tool for logging and notifying external entities about speci
 
 == Defining Events
 
-To define an event in a Starknet contract, you can use the **`#[event]`** attribute followed by defining an **`enum`** that will contain the event variants. 
+To define an event in a Starknet contract, you can use the **`#[event]`** attribute followed by defining an **`enum`** that contains the event variants. 
 [source,rust]
 ----
 #[event]

--- a/chapters/book/modules/chapter_2/pages/event.adoc
+++ b/chapters/book/modules/chapter_2/pages/event.adoc
@@ -6,9 +6,18 @@ Events are a useful tool for logging and notifying external entities about speci
 
 == Defining Events
 
-To define an event in a Starknet contract, you can use the **`#[event]`** attribute followed by the event definition. In our voting contract, we have two events, **`VoteCast`** and **`UnauthorizedAttempt`**.
+To define an event in a Starknet contract, you can use the **`#[event]`** attribute followed by defining an **`enum`** that will contain the event variants. 
+[source,rust]
+----
+#[event]
+#[derive(Drop, starknet::Event]
+enum Event {
+    VoteCast: VoteCast,
+    UnauthorizedAttempt: UnauthorizedAttempt,
+}
+----
 
-The **`VoteCast`** event is emitted when a vote is cast. The event takes two parameters: the voter's address and the vote value (0 for No, 1 for Yes).
+In our voting contract, we have two events, **`VoteCast`** and **`UnauthorizedAttempt`** which are defined in the enum above. The **`VoteCast`** event is emitted when a vote is cast. The event takes two parameters: the voter's address and the vote value (0 for No, 1 for Yes).
 
 [source,rust]
 ----


### PR DESCRIPTION
The 'Events' example lacked a crucial part where an enum containing the event variants are defined. I have added the description and the explanation is more comprehensive now.