### PR TITLE
Fixed edit_url

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -8,7 +8,7 @@ content:
   sources:
   - url: .
     branches: HEAD
-    edit_url: 'https://github.com/starknet-io/starknet-docs/edit/dev/{path}'
+    edit_url: 'https://github.com/starknet-edu/starknetbook/edit/main/{path}'
     start_paths:
       - chapters/book
 


### PR DESCRIPTION
Prevously, the edit url pointed to starknet docs.

This PR fixes that.