### PR TITLE
Fix incorrect parameter

### DIFF
--- a/chapters/book/modules/chapter_1/pages/first_contract.adoc
+++ b/chapters/book/modules/chapter_1/pages/first_contract.adoc
@@ -61,7 +61,7 @@ Currently, the "fetch" command does support Braavos or Argent X smart wallets. M
 
 [source,shell]
 ----
-starkli account fetch <SMART_WALLET_ADDRESS> ~/.starkli-wallets/deployer/account.json
+starkli account fetch <SMART_WALLET_ADDRESS> --output ~/.starkli-wallets/deployer/account.json
 ----
 
 You can see the details of the account descriptor with the following command.


### PR DESCRIPTION
starkli v0.1.13

```
starkli account fetch --help
Fetch account config from an already deployed account contract

Usage: starkli account fetch [OPTIONS] <ADDRESS>

Arguments:
  <ADDRESS>  Contract address

Options:
      --rpc <RPC>          Starknet JSON-RPC endpoint [env: STARKNET_RPC=]
      --network <NETWORK>  Starknet network [env: STARKNET_NETWORK=] [possible values: mainnet, goerli-1, goerli-2, integration]
      --force              Overwrite the file if it already exists
      --output <OUTPUT>    Path to save the account config file
      --log-traffic        Log raw request/response traffic of providers
  -h, --help               Print help
```