### PR TITLE
Fix connector ID in starknet-react

### DIFF
--- a/chapters/book/modules/chapter_2/pages/starknet-react.adoc
+++ b/chapters/book/modules/chapter_2/pages/starknet-react.adoc
@@ -60,11 +60,11 @@ export default function Connect() {
     <div>
       {connectors.map((connector) => (
         <button
-          key={connector.id()}
+          key={connector.id}
           onClick={() => connect(connector)}
           disabled={!connector.available()}
         >
-          Connect with {connector.id()}
+          Connect with {connector.id}
         </button>
       ))}
     </div>


### PR DESCRIPTION
If you copy the code from the example with `connector.id()`, you get this error:

<img width="932" alt="CleanShot 2023-09-14 at 12 47 59@2x" src="https://github.com/starknet-edu/starknetbook/assets/2598660/07ead15f-b3ea-4c6b-afcf-0584ab10444b">

It seems like `connector.id()` has been changed to `connector.id`, so this updates the docs to reflect that 👍