### PR TITLE
changing typo required to require

### DIFF
--- a/src/ch03-02-sequencers.md
+++ b/src/ch03-02-sequencers.md
@@ -162,7 +162,7 @@ href="https://github.com/lambdaclass/cairo_native">Cairo Native</a> or
 For more details on the Decentralization of Starknet, refer to the
 dedicated subchapter in this Chapter.
 
-Proving transactions doesn’t required to be decentralized (although in
+Proving transactions doesn’t require to be decentralized (although in
 the near future Starknet will operate with decentralized provers). Once
 the order is set, anyone can submit a proof; it’s either correct or not.
 However, the process that determines this order should be decentralized


### PR DESCRIPTION
'Required' is a bit confusing to the reader since it is in past tense and therefore could alter meaning, as far as the context is concerned. Hence I changed it to 'require'.

@omarespejel