### PR TITLE
Fix #[external(v0)] attribute to #[abi(embed_v0)]

### DIFF
--- a/src/ch01-00-getting-started.md
+++ b/src/ch01-00-getting-started.md
@@ -61,7 +61,7 @@ mod Ownable {
         self.owner.write(init_owner);
     }
 
-    #[external(v0)]
+    #[abi(embed_v0)]
     impl OwnableImpl of super::OwnableTrait<ContractState> {
         fn transfer_ownership(ref self: ContractState, new_owner: ContractAddress) {
             self.only_owner();


### PR DESCRIPTION
Fix markdown getting-started section contract as the `#[external(v0)]` is deprecated @l-henri @omarespejel 