### PR TITLE
Fix link to book

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
-This repository contains the source for [The Starknet Book](book.starknet.io).
+This repository contains the source for [The Starknet Book](https://book.starknet.io).
 
 ## Contribution
 


### PR DESCRIPTION
Current link is a relative link to https://github.com/estensen/starknetbook/blob/main/book.starknet.io, which yields 404