### PR TITLE
fix: PRIVTE FUNCTION in comment

### DIFF
--- a/src/ch04-05-02-multisig.md
+++ b/src/ch04-05-02-multisig.md
@@ -390,7 +390,7 @@ of the account owners. However, each change should be a transaction
 requiring the threshold number of signatures.
 
 ```rust
-    //PRIVTE FUNCTION
+    //PRIVATE FUNCTION
     //Function to add the public keys of the multisig in permanent storage
      fn add_signers(ref self: ContractState, mut signers: Span<felt252>, last: felt252) {
             match signers.pop_front() {


### PR DESCRIPTION
seems last PR `INTERNAL FUNCTION` -> `PRIVTE FUNCTION` 