### PR TITLE
fix: git clone URL in starknet-devnet.md

### DIFF
--- a/src/ch02-07-starknet-devnet.md
+++ b/src/ch02-07-starknet-devnet.md
@@ -22,7 +22,7 @@ Procedure:
 2. Clone the repository:
 
 ```shell
-git clone git@github.com:0xSpaceShard/starknet-devnet-rs.git
+git clone https://github.com/0xSpaceShard/starknet-devnet-rs.git
 ```
 
 ## Running


### PR DESCRIPTION
Stumbled upon this while trying to 
```bash
projects % git clone git@github.com:0xSpaceShard/starknet-devnet-rs.git

Cloning into 'starknet-devnet-rs'...
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
```

Fix: Replaced the git ssh url with https